### PR TITLE
update nokia.py get_credentials()

### DIFF
--- a/nokia.py
+++ b/nokia.py
@@ -82,6 +82,7 @@ class NokiaAuth(object):
     def get_credentials(self, code):
         tokens = self._oauth().fetch_token(
             '%s/oauth2/token' % self.URL,
+            include_client_id=True,       
             code=code,
             timeout=2,
             client_secret=self.consumer_secret)


### PR DESCRIPTION
Include 'include_client_id=True' parameter for fetch_token() as nokia's api now requires client_id be sent to receive token